### PR TITLE
Field name inference

### DIFF
--- a/FluentNest.Tests/EnumTests.cs
+++ b/FluentNest.Tests/EnumTests.cs
@@ -13,6 +13,26 @@ namespace FluentNest.Tests
 {
     public class EnumTests : TestsBase
     {
+        private class StringEnumContractSerializer : JsonNetSerializer
+        {
+            public StringEnumContractSerializer(IConnectionSettingsValues settings)
+                : base(settings)
+            {
+
+            }
+            protected override IList<Func<Type, JsonConverter>> ContractConverters
+                => new List<Func<Type, JsonConverter>>()
+                {
+                    t => t.IsEnum ? new StringEnumConverter() : null
+                };
+        }
+
+        public EnumTests()
+            : base(x => new StringEnumContractSerializer(x))
+        {
+
+        }
+
         public void AddSimpleTestData()
         {
             Client.DeleteIndex(CarIndex);
@@ -39,27 +59,7 @@ namespace FluentNest.Tests
             }
             Client.Flush(CarIndex);
         }
-
-        private class StringEnumContractSerializer : JsonNetSerializer
-        {
-            public StringEnumContractSerializer(IConnectionSettingsValues settings)
-                : base (settings)
-            {
-                
-            }
-            protected override IList<Func<Type, JsonConverter>> ContractConverters
-                => new List<Func<Type, JsonConverter>>()
-                {
-                    t => t.IsEnum ? new StringEnumConverter() : null
-                };
-        }
-
-        public EnumTests()
-            : base(x => new StringEnumContractSerializer(x))
-        {
-            
-        }
-
+        
         [Fact]
         public void Filtering_on_enum_property_should_work()
         {

--- a/FluentNest.Tests/FluentNest.Tests.csproj
+++ b/FluentNest.Tests/FluentNest.Tests.csproj
@@ -49,6 +49,7 @@
     <Compile Include="Model\Car.cs" />
     <Compile Include="Model\CarType.cs" />
     <Compile Include="Model\User.cs" />
+    <Compile Include="PropertyNamesTests.cs" />
     <Compile Include="StatisticsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestsBase.cs" />

--- a/FluentNest.Tests/Model/Car.cs
+++ b/FluentNest.Tests/Model/Car.cs
@@ -27,6 +27,8 @@ namespace FluentNest.Tests.Model
         public int Age { get; set; }
         public bool Enabled { get; set; }
 
+        public string BIG_CASE_NAME { get; set; }
+
         // Of course cars don't have emails, but for my tests it's usefull
         public string Email { get; set; }
     }

--- a/FluentNest.Tests/PropertyNamesTests.cs
+++ b/FluentNest.Tests/PropertyNamesTests.cs
@@ -1,0 +1,52 @@
+﻿using System.Linq;
+using FluentNest.Tests.Model;
+using Nest;
+using NFluent;
+using Tests;
+using Xunit;
+
+namespace FluentNest.Tests
+{
+    public class PropertyNamesTests : TestsBase
+    {
+        public PropertyNamesTests()
+            : base(null, connectionSettings => connectionSettings.DefaultFieldNameInferrer(p => p).DefaultTypeNameInferrer(p => p.Name))
+        {
+
+        }
+
+        private void AddSimpleTestData()
+        {
+            Client.DeleteIndex(CarIndex);
+            Client.CreateIndex(CarIndex, x => x.Mappings(m => m
+            .Map<Car>(t => t
+                .Properties(prop => prop.String(str => str.Name(s => s.Guid).Index(FieldIndexOption.NotAnalyzed)))
+                .Properties(prop => prop.String(str => str.Name(s => s.Email).Index(FieldIndexOption.NotAnalyzed)))
+            )));
+
+            for (int i = 0; i < 10; i++)
+            {
+                var car = new Car
+                {
+                    BIG_CASE_NAME = "big" + i % 3
+                };
+
+                Client.Index(car, ind => ind.Index(CarIndex));
+            }
+            Client.Flush(CarIndex);
+        }
+
+        [Fact]
+        public void TestCasing()
+        {
+            AddSimpleTestData();
+            var filter = Filters.CreateFilter<Car>(f => f.BIG_CASE_NAME == "big1");
+            filter = filter.AndFilteredOn<Car>(f => f.BIG_CASE_NAME != "big2");
+            var sc = new SearchDescriptor<Car>().FilterOn(filter);           
+            var query = Serialize(sc);
+            Check.That(query).Contains("BIG_CASE_NAME");
+            var cars = Client.Search<Car>(sc).Hits.Select(h => h.Source);
+            Check.That(cars).HasSize(3);
+        }
+    }
+}

--- a/FluentNest.Tests/TestsBase.cs
+++ b/FluentNest.Tests/TestsBase.cs
@@ -15,22 +15,26 @@ namespace Tests
         protected ElasticClient Client;
         protected IndexName CarIndex = Infer.Index<Car>();
 
-        public TestsBase(Func<ConnectionSettings, IElasticsearchSerializer> serializerFactory = null)
+        public TestsBase(Func<ConnectionSettings, IElasticsearchSerializer> serializerFactory = null, Func<ConnectionSettings, ConnectionSettings> additionalSettings = null)
         {
             var node = new Uri("http://localhost:9200");
             var connectionPool = new SingleNodeConnectionPool(node);
 
             var settings = new ConnectionSettings(connectionPool, serializerFactory).DefaultIndex("my-application" + Guid.NewGuid());
+            if (additionalSettings != null)
+            {
+                settings = additionalSettings(settings);
+            }
 
             Client = new ElasticClient(settings);
         }
 
-        public void EntityToConsole<T>(T entity)
+        public string Serialize<T>(T entity)
         {
             using (var ms = new MemoryStream())
             {
                 Client.Serializer.Serialize(entity, ms);
-                Console.WriteLine(Encoding.UTF8.GetString(ms.ToArray()));
+                return Encoding.UTF8.GetString(ms.ToArray());
             }
         }
     }

--- a/FluentNest/Filters.cs
+++ b/FluentNest/Filters.cs
@@ -111,87 +111,88 @@ namespace FluentNest
 
             var value = GetValue(binaryExpression);
             var memberAccessor = binaryExpression.Left as MemberExpression;
+            var fieldName = GetFieldNameFromMember(memberAccessor);
 
             if (value is DateTime)
             {
-                return GenerateDateComparisonFilter<T>((DateTime) value, type, memberAccessor);
+                return GenerateComparisonFilter<T>((DateTime) value, type, fieldName);
             }
             else if (value is double || value is decimal)
             {
-                return GenerateDoubleComparisonFilter<T>(Convert.ToDouble(value), type, memberAccessor);
+                return GenerateComparisonFilter<T>(Convert.ToDouble(value), type, fieldName);
             }
             else if (value is int || value is long)
             {
-                return GenerateLongComparisonFilter<T>(Convert.ToInt64(value), type, memberAccessor);
+                return GenerateComparisonFilter<T>(Convert.ToInt64(value), type, fieldName);
             }
             throw new InvalidOperationException("Comparison on non-supported type");
         }
 
-        public static QueryContainer GenerateDateComparisonFilter<T>(DateTime value, ExpressionType type, MemberExpression expression)
+        public static QueryContainer GenerateComparisonFilter<T>(DateTime value, ExpressionType type, string fieldName)
             where T : class
         {
             var filterDescriptor = new QueryContainerDescriptor<T>();
             if (type == ExpressionType.LessThan)
             {
-                return filterDescriptor.DateRange(x => x.LessThan(value).Field(expression));
+                return filterDescriptor.DateRange(x => x.LessThan(value).Field(fieldName));
             }
             else if (type == ExpressionType.GreaterThan)
             {
-                return filterDescriptor.DateRange(x => x.GreaterThan(value).Field(expression));
+                return filterDescriptor.DateRange(x => x.GreaterThan(value).Field(fieldName));
             }
             else if (type == ExpressionType.LessThanOrEqual)
             {
-                return filterDescriptor.DateRange(x => x.LessThanOrEquals(value).Field(expression));
+                return filterDescriptor.DateRange(x => x.LessThanOrEquals(value).Field(fieldName));
             }
             else if (type == ExpressionType.GreaterThanOrEqual)
             {
-                return filterDescriptor.DateRange(x => x.GreaterThanOrEquals(value).Field(expression));
+                return filterDescriptor.DateRange(x => x.GreaterThanOrEquals(value).Field(fieldName));
             }
             throw new NotImplementedException();
         }
 
-        public static QueryContainer GenerateLongComparisonFilter<T>(long value, ExpressionType type, MemberExpression expression)
+        public static QueryContainer GenerateComparisonFilter<T>(long value, ExpressionType type, string fieldName)
             where T : class
         {
             var filterDescriptor = new QueryContainerDescriptor<T>();
             if (type == ExpressionType.LessThan)
             {
-                return filterDescriptor.Range(x => x.LessThan(value).Field(expression));
+                return filterDescriptor.Range(x => x.LessThan(value).Field(fieldName));
             }
             else if (type == ExpressionType.GreaterThan)
             {
-                return filterDescriptor.Range(x => x.GreaterThan(value).Field(expression));
+                return filterDescriptor.Range(x => x.GreaterThan(value).Field(fieldName));
             }
             else if (type == ExpressionType.LessThanOrEqual)
             {
-                return filterDescriptor.Range(x => x.LessThanOrEquals(value).Field(expression));
+                return filterDescriptor.Range(x => x.LessThanOrEquals(value).Field(fieldName));
             }
             else if (type == ExpressionType.GreaterThanOrEqual)
             {
-                return filterDescriptor.Range(x => x.GreaterThanOrEquals(value).Field(expression));
+                return filterDescriptor.Range(x => x.GreaterThanOrEquals(value).Field(fieldName));
             }
             throw new NotImplementedException();
         }
 
-        public static QueryContainer GenerateDoubleComparisonFilter<T>(double value, ExpressionType type, MemberExpression expression)
+        public static QueryContainer GenerateComparisonFilter<T>(double value, ExpressionType type, string fieldName)
             where T : class
         {
             var filterDescriptor = new QueryContainerDescriptor<T>();
             if (type == ExpressionType.LessThan)
             {
-                return filterDescriptor.Range(x => x.LessThan(value).Field(expression));
+                return filterDescriptor.Range(x => x.LessThan(value).Field(fieldName));
             }
             else if (type == ExpressionType.GreaterThan)
             {
-                return filterDescriptor.Range(x => x.GreaterThan(value).Field(expression));
+                return filterDescriptor.Range(x => x.GreaterThan(value).Field(fieldName));
             }
             else if (type == ExpressionType.LessThanOrEqual)
             {
-                return filterDescriptor.Range(x => x.LessThanOrEquals(value).Field(expression));
+                return filterDescriptor.Range(x => x.LessThanOrEquals(value).Field(fieldName));
             }
             else if (type == ExpressionType.GreaterThanOrEqual)
             {
-                return filterDescriptor.Range(x => x.GreaterThanOrEquals(value).Field(expression));
+                return filterDescriptor.Range(x => x.GreaterThanOrEquals(value).Field(fieldName));
             }
             throw new NotImplementedException();
         }
@@ -201,7 +202,7 @@ namespace FluentNest
             var value = GetValue(binaryExpression);
             var queryContainerDescriptor = new QueryContainerDescriptor<T>();
             var fieldName = GetFieldName(binaryExpression.Left);
-            return queryContainerDescriptor.Term(binaryExpression.Left, value);
+            return queryContainerDescriptor.Term(fieldName, value);
         }
 
         public static QueryContainer GenerateNotEqualFilter<T>(this BinaryExpression expression) where T : class
@@ -232,7 +233,12 @@ namespace FluentNest
             }
             throw new NotImplementedException();
         }
-        
+
+        public static string GetFieldNameFromMember(this MemberExpression expression)
+        {
+            return FirstCharacterToLower(expression.Member.Name);
+        }
+
         public static QueryContainer GenerateFilterDescription<T>(this Expression expression) where T:class
         {
             var expType = expression.NodeType;

--- a/FluentNest/Filters.cs
+++ b/FluentNest/Filters.cs
@@ -111,88 +111,87 @@ namespace FluentNest
 
             var value = GetValue(binaryExpression);
             var memberAccessor = binaryExpression.Left as MemberExpression;
-            var fieldName = GetFieldNameFromMember(memberAccessor);
 
             if (value is DateTime)
             {
-                return GenerateComparisonFilter<T>((DateTime) value, type, fieldName);
+                return GenerateDateComparisonFilter<T>((DateTime) value, type, memberAccessor);
             }
             else if (value is double || value is decimal)
             {
-                return GenerateComparisonFilter<T>(Convert.ToDouble(value), type, fieldName);
+                return GenerateDoubleComparisonFilter<T>(Convert.ToDouble(value), type, memberAccessor);
             }
             else if (value is int || value is long)
             {
-                return GenerateComparisonFilter<T>(Convert.ToInt64(value), type, fieldName);
+                return GenerateLongComparisonFilter<T>(Convert.ToInt64(value), type, memberAccessor);
             }
             throw new InvalidOperationException("Comparison on non-supported type");
         }
 
-        public static QueryContainer GenerateComparisonFilter<T>(DateTime value, ExpressionType type, string fieldName)
+        public static QueryContainer GenerateDateComparisonFilter<T>(DateTime value, ExpressionType type, MemberExpression expression)
             where T : class
         {
             var filterDescriptor = new QueryContainerDescriptor<T>();
             if (type == ExpressionType.LessThan)
             {
-                return filterDescriptor.DateRange(x => x.LessThan(value).Field(fieldName));
+                return filterDescriptor.DateRange(x => x.LessThan(value).Field(expression));
             }
             else if (type == ExpressionType.GreaterThan)
             {
-                return filterDescriptor.DateRange(x => x.GreaterThan(value).Field(fieldName));
+                return filterDescriptor.DateRange(x => x.GreaterThan(value).Field(expression));
             }
             else if (type == ExpressionType.LessThanOrEqual)
             {
-                return filterDescriptor.DateRange(x => x.LessThanOrEquals(value).Field(fieldName));
+                return filterDescriptor.DateRange(x => x.LessThanOrEquals(value).Field(expression));
             }
             else if (type == ExpressionType.GreaterThanOrEqual)
             {
-                return filterDescriptor.DateRange(x => x.GreaterThanOrEquals(value).Field(fieldName));
+                return filterDescriptor.DateRange(x => x.GreaterThanOrEquals(value).Field(expression));
             }
             throw new NotImplementedException();
         }
 
-        public static QueryContainer GenerateComparisonFilter<T>(long value, ExpressionType type, string fieldName)
+        public static QueryContainer GenerateLongComparisonFilter<T>(long value, ExpressionType type, MemberExpression expression)
             where T : class
         {
             var filterDescriptor = new QueryContainerDescriptor<T>();
             if (type == ExpressionType.LessThan)
             {
-                return filterDescriptor.Range(x => x.LessThan(value).Field(fieldName));
+                return filterDescriptor.Range(x => x.LessThan(value).Field(expression));
             }
             else if (type == ExpressionType.GreaterThan)
             {
-                return filterDescriptor.Range(x => x.GreaterThan(value).Field(fieldName));
+                return filterDescriptor.Range(x => x.GreaterThan(value).Field(expression));
             }
             else if (type == ExpressionType.LessThanOrEqual)
             {
-                return filterDescriptor.Range(x => x.LessThanOrEquals(value).Field(fieldName));
+                return filterDescriptor.Range(x => x.LessThanOrEquals(value).Field(expression));
             }
             else if (type == ExpressionType.GreaterThanOrEqual)
             {
-                return filterDescriptor.Range(x => x.GreaterThanOrEquals(value).Field(fieldName));
+                return filterDescriptor.Range(x => x.GreaterThanOrEquals(value).Field(expression));
             }
             throw new NotImplementedException();
         }
 
-        public static QueryContainer GenerateComparisonFilter<T>(double value, ExpressionType type, string fieldName)
+        public static QueryContainer GenerateDoubleComparisonFilter<T>(double value, ExpressionType type, MemberExpression expression)
             where T : class
         {
             var filterDescriptor = new QueryContainerDescriptor<T>();
             if (type == ExpressionType.LessThan)
             {
-                return filterDescriptor.Range(x => x.LessThan(value).Field(fieldName));
+                return filterDescriptor.Range(x => x.LessThan(value).Field(expression));
             }
             else if (type == ExpressionType.GreaterThan)
             {
-                return filterDescriptor.Range(x => x.GreaterThan(value).Field(fieldName));
+                return filterDescriptor.Range(x => x.GreaterThan(value).Field(expression));
             }
             else if (type == ExpressionType.LessThanOrEqual)
             {
-                return filterDescriptor.Range(x => x.LessThanOrEquals(value).Field(fieldName));
+                return filterDescriptor.Range(x => x.LessThanOrEquals(value).Field(expression));
             }
             else if (type == ExpressionType.GreaterThanOrEqual)
             {
-                return filterDescriptor.Range(x => x.GreaterThanOrEquals(value).Field(fieldName));
+                return filterDescriptor.Range(x => x.GreaterThanOrEquals(value).Field(expression));
             }
             throw new NotImplementedException();
         }
@@ -202,7 +201,7 @@ namespace FluentNest
             var value = GetValue(binaryExpression);
             var queryContainerDescriptor = new QueryContainerDescriptor<T>();
             var fieldName = GetFieldName(binaryExpression.Left);
-            return queryContainerDescriptor.Term(fieldName, value);
+            return queryContainerDescriptor.Term(binaryExpression.Left, value);
         }
 
         public static QueryContainer GenerateNotEqualFilter<T>(this BinaryExpression expression) where T : class
@@ -233,12 +232,7 @@ namespace FluentNest
             }
             throw new NotImplementedException();
         }
-
-        public static string GetFieldNameFromMember(this MemberExpression expression)
-        {
-            return FirstCharacterToLower(expression.Member.Name);
-        }
-
+        
         public static QueryContainer GenerateFilterDescription<T>(this Expression expression) where T:class
         {
             var expType = expression.NodeType;


### PR DESCRIPTION
This is them minimum to let NEST infer the property names by it's means, instead of doing this for him.
The tricky part that the Term method method for NEST (used by most of the filters) takes a Expression<Func<T, object>> which is great, but if we are in a middle of recursive analysis of a complex filter, we don't have typed expression anymore, so this has to be reconstructed.