### PR TITLE
added an overload to AndValueWithin to take a single element + tests

### DIFF
--- a/FluentNest.Tests/FilterTests.cs
+++ b/FluentNest.Tests/FilterTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using FluentNest.Tests.Model;
 using Nest;
 using NFluent;
@@ -20,6 +21,7 @@ namespace FluentNest.Tests
             .Map<Car>(t => t
                 .Properties(prop => prop.Keyword(str => str.Name(s => s.Guid)))
                 .Properties(prop => prop.Keyword(str => str.Name(s => s.Email)))
+                .Properties(prop => prop.Keyword(str => str.Name(s => s.PreviousOwners)))
             )));
 
             var cars = new List<Car>();
@@ -39,7 +41,8 @@ namespace FluentNest.Tests
                     Age = i + 1,
                     Enabled = i % 2 == 0,
                     Active = i % 2 == 0,
-                    Weight = i % 3 == 0 ? 10m : (decimal?)null
+                    Weight = i % 3 == 0 ? 10m : (decimal?)null,
+                    PreviousOwners = i % 2 == 0 ? null : i % 3 == 0 ? new string[0] : Enumerable.Range(0, i).Select(n => $"Owner n°{n}").ToArray()
                 };
                 if (i == 1)
                 {
@@ -267,6 +270,36 @@ namespace FluentNest.Tests
             var index = AddSimpleTestData();
             var result = Client.Search<Car>(sc => sc.Index(index).FilterOn(x => x.Guid == MyFavoriteGuid));
             Check.That(result.Documents).HasSize(1);
+            Client.DeleteIndex(index);
+        }
+
+        [Fact]
+        public void Filter_ValueWithin_SingleItem()
+        {
+            var item = "Owner n°0";
+            var index = AddSimpleTestData();
+            var result = Client.Search<Car>(sc => sc.Index(index).FilterOn(Filters.ValueWithin<Car>(x => x.PreviousOwners, item)).TypedKeys(null));
+            Check.That(result.Documents).Not.HasSize(0);
+            foreach (var previousOwners in result.Documents.Select(d => d.PreviousOwners))
+            {
+                Check.That(previousOwners).Contains(item);
+            }
+
+            Client.DeleteIndex(index);
+        }
+
+        [Fact]
+        public void Filter_ValueWithin_MultipleItems()
+        {
+            var items = new[] { "Owner n°0", "Onwer n°1" };
+            var index = AddSimpleTestData();
+            var result = Client.Search<Car>(sc => sc.Index(index).FilterOn(Filters.ValueWithin<Car>(x => x.PreviousOwners, items)).TypedKeys(null));
+            Check.That(result.Documents).Not.HasSize(0);
+            foreach (var previousOwners in result.Documents.Select(d => d.PreviousOwners))
+            {
+                Check.That(previousOwners.Join(items, a => a, b => b, (a, b) => 0)).Not.HasSize(0);
+            }
+
             Client.DeleteIndex(index);
         }
 

--- a/FluentNest.Tests/Model/Car.cs
+++ b/FluentNest.Tests/Model/Car.cs
@@ -35,5 +35,7 @@ namespace FluentNest.Tests.Model
         public string Email { get; set; }
         public DateTime? LastControlCheck { get; set; }
         public DateTime? LastAccident { get; set; }
+
+        public string[] PreviousOwners { get; set; }
     }
 }

--- a/FluentNest.Tests/StatisticsTests.cs
+++ b/FluentNest.Tests/StatisticsTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using FluentNest.Tests.Model;
+using Nest;
 using NFluent;
 using Tests;
 using Xunit;

--- a/FluentNest/Filters.cs
+++ b/FluentNest/Filters.cs
@@ -402,6 +402,14 @@ namespace FluentNest
             return filterDescriptor.Bool(x => x.Must(queryDescriptor, newPartOfQuery));
         }
 
+        public static QueryContainer AndValueWithin<T>(this QueryContainer queryDescriptor, Expression<Func<T, Object>> fieldGetter, string item) where T : class
+        {
+            var filterDescriptor = new QueryContainerDescriptor<T>();
+            var newFilter = new QueryContainerDescriptor<T>();
+            var newPartOfQuery = newFilter.Term(term => term.Value(item).Field(fieldGetter));
+            return filterDescriptor.Bool(x => x.Must(queryDescriptor, newPartOfQuery));
+        }
+
         public static QueryContainer CreateFilter<T>(Expression<Func<T, bool>> filterRule) where T : class
         {
             return GenerateFilterDescription<T>(filterRule);
@@ -410,6 +418,11 @@ namespace FluentNest
         public static QueryContainer ValueWithin<T>(Expression<Func<T, object>> propertyGetter, IEnumerable<string> list) where T : class
         {
             return new QueryContainerDescriptor<T>().AndValueWithin(propertyGetter, list);
+        }
+
+        public static QueryContainer ValueWithin<T>(Expression<Func<T, object>> propertyGetter, string item) where T : class
+        {
+            return new QueryContainerDescriptor<T>().AndValueWithin(propertyGetter, item);
         }
 
         private static object GetValue(BinaryExpression binaryExpression)


### PR DESCRIPTION
`AndValueWithin` always checked two arrays against each other

this PR introduces an overload that allows to filter an item against an array of value in the indexed document